### PR TITLE
Remove dependency on spring-boot-starter-websocket, and override open…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,16 +25,17 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-        <!-- Dep required - Why ? -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-websocket</artifactId>
-        </dependency>
 
         <!-- OpenTracing -->
         <dependency>
             <groupId>io.opentracing.contrib</groupId>
             <artifactId>opentracing-spring-cloud-starter</artifactId>
+            <version>0.0.7</version>
+        </dependency>
+        <!-- Required until bom updated, as currently specifies opentracing-spring-cloud:0.0.4 -->
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-cloud</artifactId>
             <version>0.0.7</version>
         </dependency>
         <!-- Jaeger -->


### PR DESCRIPTION
…tracing-spring-cloud version currently defined in bom

Probably best to just have the `opentracing-spring-cloud-starter` dependency defined in the bom?