### PR TITLE
Remove dependency on websocket and pin ot-cloud version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,6 @@
             <artifactId>spring-boot-starter-log4j2</artifactId>
             <version>1.5.8.RELEASE</version>
         </dependency>
-        <!-- Dep required - Why ? -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-websocket</artifactId>
-        </dependency>
 
         <!-- OpenTracing -->
         <dependency>
@@ -42,6 +37,13 @@
             <artifactId>opentracing-spring-cloud-starter</artifactId>
             <version>0.0.7</version>
         </dependency>
+        <!-- Pin the impl otherwise is overridden by parent -->
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-cloud</artifactId>
+            <version>0.0.7</version>
+        </dependency>
+
         <!-- Jaeger -->
         <dependency>
             <groupId>com.uber.jaeger</groupId>


### PR DESCRIPTION
CNFE was caused because by bug in ot-cloud 0.4.0 which was
added by parent pom. 

If you want to change the version of opentracing-spring-cloud you have to pin two dependencies. See https://github.com/snowdrop/spring-boot-bom/blob/sb-1.5.x/pom.xml#L843