### PR TITLE
Remove the Multiple SLF4J Bindings warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Since log4j2 has been included, we need to explicitly exclude the
logging-starter which pulls logback by default