### PR TITLE
Consolidate Jaeger properties into single object

### DIFF
--- a/src/main/java/me/snowdrop/JaegerProperties.java
+++ b/src/main/java/me/snowdrop/JaegerProperties.java
@@ -1,0 +1,38 @@
+package me.snowdrop;
+
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jaeger")
+public class JaegerProperties {
+
+    private String sender;
+
+    private String protocol;
+
+    private int port;
+
+    public String getSender() {
+        return sender;
+    }
+
+    public void setSender(String sender) {
+        this.sender = sender;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+}


### PR DESCRIPTION
This could used later on as the base for auto-configuration.

The only thing to note however is that `@ConfigurationProperties` does not behave in the same way as  `@Value` when the placeholder cannot be resolved. `@Value` failes, while `@ConfigurationProperties` does not. See [this](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config-vs-value) part of the documentation.

In our case if the placeholder cannot be resolved the app will still fail to start, just not in the same way as previously with `@Value`